### PR TITLE
required since upgrade to keep connection open

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const streamApiStore = {};
 
 const initSocket = (apiKey) => {
   const uri = config.io.server + '/' + config.io.namespace.allFilings;
-  const params = { query: { apiKey } };
+  const params = { query: { apiKey }, transports: ['websocket'] };
   streamApiStore.socket = io(uri, params);
   streamApiStore.socket.on('connect', () =>
     console.log('Socket connected to', uri)


### PR DESCRIPTION
I got an email from sec-api.io to upgrade the API. Please check it.




I just wanted to let you know that our recent infrastructure upgrade yesterday requires your SEC API real-time client to use the websocket transport protocol.

You can find a Node.js code example below. The "transports" key is also available in other languages, such as Python.
```const io = require('socket.io-client');

const streamApiClient = io('https://api.sec-api.io:3334/all-filings', {
  query: { apiKey: 'YOUR_API_KEY' },
  transports: ['websocket'] // required since yesterday to keep connection open
})```

Please let me know if you have any questions.